### PR TITLE
Sdt 224

### DIFF
--- a/__test__/Inspectores.e2e.js
+++ b/__test__/Inspectores.e2e.js
@@ -1,0 +1,38 @@
+const supertest = require('supertest');
+const {
+  apiKey,
+  upServer,
+  downServer,
+  statusCodeName,
+} = require('./utils/fixtures/server');
+const { upSeed, downSeed } = require('./utils/umzug');
+const { createInpector } = require('./utils/fixtures/inspector');
+
+describe('Test for inspectores', () => {
+  let api = null;
+  let inspector = null;
+  beforeAll(async () => {
+    api = supertest(await upServer());
+    await upSeed();
+    inspector = await createInpector();
+  });
+  describe('[POST] /api/v1/inspecciones/inspectores-programas', () => {
+    it('should new inspector program', async () => {
+      const { statusCode, body } = await api.post('/api/v1/inspecciones/inspectores-programas')
+        .send({ inspectorId: inspector.id, programaId: 1 })
+        .set(apiKey);
+      expect(statusCode).toEqual(statusCodeName.created);
+      expect(body.data.inspectorId).toEqual(inspector.id);
+    });
+    it('should a error', async () => {
+      const { statusCode } = await api.post('/api/v1/inspecciones/inspectores-programas')
+        .send({ inspectorId: inspector.id, programaId: 100 })
+        .set(apiKey);
+      expect(statusCode).toEqual(statusCodeName.notFound);
+    });
+  });
+  afterAll(async () => {
+    await downSeed();
+    await downServer();
+  });
+});

--- a/__test__/utils/fixtures/inspector.js
+++ b/__test__/utils/fixtures/inspector.js
@@ -1,0 +1,16 @@
+const { createUserDb } = require('./server');
+const { models } = require('../../../packages/core/src/drivers/db/connection');
+
+const createUserInspector = {
+  usuario: 'inspector',
+  rolId: 6,
+  correo: 'inspector@gmail.com',
+  contrasena: 'Qwerty1234@',
+};
+const createInpector = async () => {
+  const { personaId } = await createUserDb(createUserInspector);
+  const inspector = await models.Inspector.create({ personaId });
+  return inspector;
+};
+
+module.exports = { createInpector };

--- a/packages/api-gateway/package.json
+++ b/packages/api-gateway/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@fastify/autoload": "^5.0.0",
     "@fastify/cors": "^8.0.0",
-    "@fastify/helmet": "^9.1.0",
+    "@fastify/helmet": "^10.0.2",
     "@fastify/jwt": "^7.0.0",
     "@fastify/static": "^6.5.0",
     "@fastify/swagger": "^7.4.1",
@@ -41,7 +41,7 @@
     "@siiges-services/shared": "^0.0.1",
     "@siiges-services/solicitudes": "^1.0.0",
     "@siiges-services/usuario": "^1.0.0",
-    "fastify": "^4.2.0",
+    "fastify": "^4.9.2",
     "fastify-multer": "^2.0.3",
     "fastify-plugin": "^4.0.0"
   }

--- a/packages/api-gateway/src/drivers/http/adapters/inspecciones/handlers/create.handlers.inspectores-programas.adapters.js
+++ b/packages/api-gateway/src/drivers/http/adapters/inspecciones/handlers/create.handlers.inspectores-programas.adapters.js
@@ -1,0 +1,20 @@
+const { Logger } = require('@siiges-services/shared');
+const errorHandler = require('../../../utils/errorHandler');
+
+async function createInspectoresProgramas(req, reply) {
+  try {
+    const { ...data } = req.body;
+    Logger.info('[Inspector programas]: Creating inspector program');
+
+    const newInspectorProgram = await this.inspeccionServices.createInspectorProgramas(data);
+
+    return reply
+      .code(201)
+      .header('Content-Type', 'application/json; charset=utf-8')
+      .send({ data: newInspectorProgram });
+  } catch (error) {
+    return errorHandler(error, reply);
+  }
+}
+
+module.exports = createInspectoresProgramas;

--- a/packages/api-gateway/src/drivers/http/adapters/inspecciones/handlers/index.js
+++ b/packages/api-gateway/src/drivers/http/adapters/inspecciones/handlers/index.js
@@ -3,6 +3,7 @@ const createInspeccion = require('./create.handlers.inspeccion.adapters');
 const createInspeccionRespuestas = require('./create.handlers.inspeccion-respuestas.adapters');
 const createInspeccionObservacion = require('./create.handlers.inspeccion-observacion.adapters');
 const deleteInspeccion = require('./delete.handlers.inspeccion.adapters');
+const createInspectoresProgramas = require('./create.handlers.inspectores-programas.adapters');
 
 module.exports = {
   createInspeccion,
@@ -10,4 +11,5 @@ module.exports = {
   createInspeccionRespuestas,
   createInspeccionObservacion,
   deleteInspeccion,
+  createInspectoresProgramas,
 };

--- a/packages/api-gateway/src/drivers/http/routes/inspecciones/index.js
+++ b/packages/api-gateway/src/drivers/http/routes/inspecciones/index.js
@@ -6,6 +6,7 @@ const {
   createInspeccionRespuestasSchema,
   createInspeccionObservacionSchema,
   deleteInspeccionSchema,
+  createInspectoresProgramasSchema,
 } = require('./schema');
 
 async function inspeccionRouter(fastify, opts, next) {
@@ -37,6 +38,12 @@ async function inspeccionRouter(fastify, opts, next) {
     '/:inspeccionId',
     { schema: deleteInspeccionSchema },
     inspeccionesAdapter.deleteInspeccion,
+  );
+
+  await fastify.post(
+    '/inspectores-programas',
+    { schema: createInspectoresProgramasSchema },
+    inspeccionesAdapter.createInspectoresProgramas,
   );
 
   next();

--- a/packages/api-gateway/src/drivers/http/routes/inspecciones/schema/craate.inspectores-programas.schema.js
+++ b/packages/api-gateway/src/drivers/http/routes/inspecciones/schema/craate.inspectores-programas.schema.js
@@ -1,0 +1,31 @@
+const { inspectoresProgramas } = require('./properties/inspectoresProgramas');
+const { responseProperties } = require('./properties/responseProperties');
+
+const createInspectoresProgramasSchema = {
+  tags: ['inspectores'],
+  description: 'Create a new inspector program',
+  body: {
+    type: 'object',
+    properties: {
+      ...inspectoresProgramas,
+    },
+    required: ['inspectorId', 'programaId'],
+  },
+  reponse: {
+    201: {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'array',
+          properties: {
+            id: { type: 'integer' },
+            ...inspectoresProgramas,
+            ...responseProperties,
+          },
+        },
+      },
+    },
+  },
+};
+
+module.exports = createInspectoresProgramasSchema;

--- a/packages/api-gateway/src/drivers/http/routes/inspecciones/schema/index.js
+++ b/packages/api-gateway/src/drivers/http/routes/inspecciones/schema/index.js
@@ -3,6 +3,7 @@ const createInspeccionSchema = require('./create.inspeccion.schema');
 const createInspeccionRespuestasSchema = require('./create.inspeccion-respuestas.schema');
 const createInspeccionObservacionSchema = require('./create.inspeccion-observacion.schema');
 const deleteInspeccionSchema = require('./delete.inspeccion.schema');
+const createInspectoresProgramasSchema = require('./craate.inspectores-programas.schema');
 
 module.exports = {
   createInspeccionSchema,
@@ -10,4 +11,5 @@ module.exports = {
   createInspeccionRespuestasSchema,
   createInspeccionObservacionSchema,
   deleteInspeccionSchema,
+  createInspectoresProgramasSchema,
 };

--- a/packages/api-gateway/src/drivers/http/routes/inspecciones/schema/properties/inspectoresProgramas.js
+++ b/packages/api-gateway/src/drivers/http/routes/inspecciones/schema/properties/inspectoresProgramas.js
@@ -1,0 +1,6 @@
+const inspectoresProgramas = {
+  inspectorId: { type: 'integer' },
+  programaId: { type: 'integer' },
+};
+
+module.exports = { inspectoresProgramas };

--- a/packages/core/src/drivers/db/models/inspectorPrograma.js
+++ b/packages/core/src/drivers/db/models/inspectorPrograma.js
@@ -59,7 +59,7 @@ class InspectorPrograma extends Model {
     return {
       sequelize,
       tableName: INSPECTOR_PROGRAMA_TABLE,
-      modelName: 'InspecctorPrograma',
+      modelName: 'InspectorPrograma',
       timestamps: false,
     };
   }

--- a/packages/inspecciones/src/adapters/db/inspecciones/inspecciones.db.adapters.js
+++ b/packages/inspecciones/src/adapters/db/inspecciones/inspecciones.db.adapters.js
@@ -6,7 +6,9 @@ const {
   InspeccionPregunta,
   InspeccionInspeccionPregunta,
   InspeccionObservacion,
-
+  InspectorPrograma,
+  Programa,
+  Inspector,
 } = models;
 
 const {
@@ -30,4 +32,7 @@ module.exports = {
   findOneInspeccionObservacionQuery: findOneQuery(InspeccionObservacion),
   updateInspeccionObservacionQuery: updateAndFindQuery(InspeccionObservacion),
   updateInspeccionInspeccionPreguntaQuery: updateAndFindQuery(InspeccionInspeccionPregunta),
+  createInspectorProgramasQuery: createQuery(InspectorPrograma),
+  findOneProgramasQuery: findOneQuery(Programa),
+  findOneInspectorQuery: findOneQuery(Inspector),
 };

--- a/packages/inspecciones/src/use-cases/db/inspecciones/create.inspector-programas.use-cases.js
+++ b/packages/inspecciones/src/use-cases/db/inspecciones/create.inspector-programas.use-cases.js
@@ -1,0 +1,18 @@
+const { checkers } = require('@siiges-services/shared');
+
+const createInspectorProgramas = (
+  createInspectorProgramasQuery,
+  findOneInspectorQuery,
+  findOneProgramasQuery,
+) => async (data) => {
+  const { programaId, inspectorId } = data;
+  const inspector = await findOneInspectorQuery({ id: inspectorId });
+  checkers.throwErrorIfDataIsFalsy(inspector, 'InspectorPrograma', inspectorId);
+  const programa = await findOneProgramasQuery({ id: programaId });
+  checkers.throwErrorIfDataIsFalsy(programa, 'InspectorPrograma', programaId);
+
+  const newInspectorProgramas = await createInspectorProgramasQuery(data);
+  return newInspectorProgramas;
+};
+
+module.exports = createInspectorProgramas;

--- a/packages/inspecciones/src/use-cases/db/inspecciones/index.js
+++ b/packages/inspecciones/src/use-cases/db/inspecciones/index.js
@@ -7,6 +7,7 @@ const deleteInspeccion = require('./delete.inspeccion.use-cases');
 const findAllInspeccionPreguntas = require('./find-all.inspeccion-preguntas.use-cases');
 const createInspeccionRespuestas = require('./create.inspeccion.inspeccion-respuesta.use-cases');
 const createInspeccionObservacion = require('./create.inspeccion-observacion.use-cases');
+const createInspectorProgramas = require('./create.inspector-programas.use-cases');
 
 module.exports = {
   createInspeccion: createInspeccion(
@@ -30,5 +31,10 @@ module.exports = {
   deleteInspeccion: deleteInspeccion(
     inspecciones.findOneQuery,
     inspecciones.deleteQuery,
+  ),
+  createInspectorProgramas: createInspectorProgramas(
+    inspecciones.createInspectorProgramasQuery,
+    inspecciones.findOneInspectorQuery,
+    inspecciones.findOneProgramasQuery,
   ),
 };

--- a/packages/inspecciones/src/use-cases/index.js
+++ b/packages/inspecciones/src/use-cases/index.js
@@ -4,6 +4,7 @@ const {
   createInspeccionRespuestas,
   deleteInspeccion,
   createInspeccionObservacion,
+  createInspectorProgramas,
 } = require('./db/inspecciones');
 
 module.exports = {
@@ -12,4 +13,5 @@ module.exports = {
   createInspeccionRespuestas,
   createInspeccionObservacion,
   deleteInspeccion,
+  createInspectorProgramas,
 };


### PR DESCRIPTION
Se crea inspector-programa, con sus respectivos test e2e.
Se elimino el siguiente warnirg:
`(node:252) [FSTDEP012] FastifyDeprecation: Request#context property access is deprecated. Please use "Request#routeConfig" or "Request#routeSchema" instead for accessing Route settings. The "Request#context" will be removed in 'fastify@5'.`
Aparecía cada vez que se ejecutaba un endpoint y hacia ruido a la hora de ejecutar pruebas u observar los Logs