### PR TITLE
Modificar endpoint para crear solicitudes (POST) agregando opción REFRENDO - SDT 521

### DIFF
--- a/packages/api-gateway/src/drivers/http/adapters/solicitudes/handlers/create.handlers.solicitud-programa.adapters.js
+++ b/packages/api-gateway/src/drivers/http/adapters/solicitudes/handlers/create.handlers.solicitud-programa.adapters.js
@@ -5,7 +5,7 @@ const errorHandler = require('../../../utils/errorHandler');
 async function createSolicitudPrograma(req, reply) {
   try {
     const { ...data } = req.body;
-    const { solicitudId } = req.params;
+    const { solicitudId } = req.query;
     const { tipoSolicitudId } = data;
 
     Logger.info('[solicitudes]: Creating solicitud');

--- a/packages/api-gateway/src/drivers/http/routes/solicitudes/schema/create.solicitud-programa.schema.js
+++ b/packages/api-gateway/src/drivers/http/routes/solicitudes/schema/create.solicitud-programa.schema.js
@@ -6,6 +6,12 @@ const { responseProperties } = require('./properties/responseProperties');
 const createSolicitudProgramaSchema = {
   tags: ['Solicitudes'],
   description: 'Given an object with solicitud and programa required data, then save the first time a new solicitud in database.',
+  querystring: {
+    type: 'object',
+    properties: {
+      solicitudId: { type: 'integer' },
+    },
+  },
   body: {
     type: 'object',
     properties: {
@@ -23,10 +29,8 @@ const createSolicitudProgramaSchema = {
             },
           },
         },
-        required: ['cicloId', 'nivelId', 'modalidadId', 'plantelId', 'programaTurnos'],
       },
     },
-    required: ['tipoSolicitudId', 'usuarioId', 'estatusSolicitudId', 'programa'],
     additionalProperties: false,
   },
   response: {

--- a/packages/core/src/drivers/db/models/solicitud.js
+++ b/packages/core/src/drivers/db/models/solicitud.js
@@ -83,6 +83,7 @@ class Solicitud extends Model {
     this.belongsTo(models.EstatusSolicitud, { as: 'estatusSolicitud' });
     this.hasOne(models.Programa, { as: 'programa', foreignKey: 'solicitudId' });
     this.hasMany(models.Diligencia, { as: 'diligencias', foreignKey: 'solicitudId' });
+    this.hasMany(models.Representante, { as: 'representante', foreignKey: 'solicitudId' });
   }
 
   static config(sequelize) {

--- a/packages/solicitudes/src/use-cases/db/solicitudes/create.solicitud-refrendo-programa.use-cases.js
+++ b/packages/solicitudes/src/use-cases/db/solicitudes/create.solicitud-refrendo-programa.use-cases.js
@@ -1,13 +1,9 @@
-/* eslint-disable no-param-reassign */
-/* eslint-disable no-restricted-syntax */
 const { checkers } = require('@siiges-services/shared');
 const boom = require('@hapi/boom');
 const { createFolioSolicitud } = require('../../../utils/create-folio.utils');
 
-const ROL_REPRESENTANTE = 3;
-
 function removeIds(obj) {
-  if (typeof obj !== 'object' || obj === null) {
+  if (typeof obj !== 'object' || obj === null || obj instanceof Date) {
     return obj;
   }
 
@@ -15,19 +11,18 @@ function removeIds(obj) {
     return obj.map(removeIds);
   }
 
-  for (const key in obj) {
-    if (
-      key === 'id'
-      || key === 'createdAt'
-      || key === 'updatedAt'
-      || key === 'deletedAt') {
-      delete obj[key];
-    } else {
-      obj[key] = removeIds(obj[key]);
-    }
-  }
+  const keysToRemove = ['id', 'createdAt', 'updatedAt', 'deletedAt'];
 
-  return obj;
+  const newObj = Object.keys(obj)
+    .filter((key) => !keysToRemove.includes(key))
+    .reduce((acc, key) => {
+      if (typeof obj[key] === 'object') {
+        return { ...acc, [key]: removeIds(obj[key]) };
+      }
+      return { ...acc, [key]: obj[key] };
+    }, {});
+
+  return newObj;
 }
 
 const createRefrendoSolicitudPrograma = (
@@ -36,87 +31,52 @@ const createRefrendoSolicitudPrograma = (
   countSolicitudesQuery,
   createSolicitudProgramaQuery,
 ) => async (identifierObj, data) => {
-  const { usuarioId, tipoSolicitudId } = data;
+  const { tipoSolicitudId } = data;
   const { solicitudId } = identifierObj;
 
   if (tipoSolicitudId !== 2) {
     throw boom.badRequest(
       '[solicitudes]: Tipo Solicitud is not correct',
     );
-  } else {
-    const usuario = await findOneUsuarioQuery({ id: usuarioId });
-    checkers.throwErrorIfDataIsFalsy(usuario, 'usuarios', usuarioId);
-
-    const include = [{
-      association: 'programa',
-    },
-      /*       include: [
-        { association: 'programaTurnos' },
-        { association: 'asignaturas' },
-        {
-          association: 'docentes',
-          include: [
-            { association: 'persona' },
-            { association: 'asignaturasDocentes' },
-          ],
-        },
-        { association: 'trayectorias' },
-      ],
-    },
-    {
-      association: 'diligencias',
-      include: [{ association: 'persona' }],
-    },
-    { association: 'estatusSolicitud' } */
-    ];
-
-    const solicitud = await findOneSolicitudQuery({ id: solicitudId }, {
-      undefined,
-      include,
-      strict: false,
-    });
-    checkers.throwErrorIfDataIsFalsy(solicitud, 'solicitudes', solicitudId);
-
-    const solicitudData = solicitud.toJSON();
-
-    // Assuming solicitudData is your response object
-    const solicitudDataWithoutIds = removeIds(solicitudData);
-    console.log(solicitudDataWithoutIds);
-
-    /* if (usuario.rolId !== ROL_REPRESENTANTE) {
-    throw boom.badRequest(
-      '[solicitudes]: The user is not a REPRESENTANTE role',
-    );
-  } */
-
-    // Extract the data values from the original object
-    const totalSolicitudes = await countSolicitudesQuery();
-    const folioSolcitud = createFolioSolicitud(totalSolicitudes, data.programa.nivelId);
-    console.log(folioSolcitud);
-
-    const newData = { ...solicitudDataWithoutIds, folio: folioSolcitud };
-
-    // Create a new solicitud object with the extracted data
-    const newSolicitud = await createSolicitudProgramaQuery({
-      ...newData,
-    }, include);
-
-    checkers.throwErrorIfDataIsFalsy(newSolicitud, 'solicitudes', newSolicitud.id);
-
-    /* const newProgramaTurnosArray = await Promise.all(
-      data.programa.programaTurnos.map(async (programaTurno) => {
-        const newProgramaTurno = await createProgramaTurnoQuery({
-          turnoId: programaTurno,
-          programaId: newSolicitud.programa.id,
-        });
-        return newProgramaTurno.dataValues;
-      }),
-    );
-
-    newSolicitud.dataValues.programa.dataValues.programaTurnos = newProgramaTurnosArray;
- */
-    return newSolicitud;
   }
+  const include = [{
+    association: 'programa',
+    include: [
+      { association: 'programaTurnos' },
+      { association: 'asignaturas' },
+      { association: 'trayectoria' },
+    ],
+  },
+  { association: 'representante' },
+  ];
+
+  const solicitud = await findOneSolicitudQuery({ id: solicitudId }, {
+    undefined,
+    include,
+    strict: false,
+  });
+  checkers.throwErrorIfDataIsFalsy(solicitud, 'solicitudes', solicitudId);
+
+  const solicitudData = solicitud.toJSON();
+
+  // Assuming solicitudData is your response object
+  const solicitudDataWithoutIds = removeIds(solicitudData);
+
+  // Extract the data values from the original object
+  const totalSolicitudes = await countSolicitudesQuery();
+  const folioSolcitud = createFolioSolicitud(totalSolicitudes, solicitudDataWithoutIds
+    .programa.nivelId);
+
+  const newData = { ...solicitudDataWithoutIds, folio: folioSolcitud, tipoSolicitudId: 2 };
+
+  // Create a new solicitud object with the extracted data
+  const newSolicitud = await createSolicitudProgramaQuery({
+    ...newData,
+  }, include);
+
+  checkers.throwErrorIfDataIsFalsy(newSolicitud, 'solicitudes', newSolicitud.id);
+
+  return newSolicitud;
 };
 
 module.exports = createRefrendoSolicitudPrograma;


### PR DESCRIPTION

Actualmente, el endpoint de creación de solicitudes crea nuevas solicitudes por defecto. Se requiere modificar este comportamiento para permitir la creación de solicitudes de tipo REFRENDO, así como también contemplar otras opciones como CAMBIO DE DOMICILIO (otro ticket)

**Cambios Necesarios:**

1.  **Adición de Query Parameters:**  
    Se deben agregar query parameters al endpoint para especificar el tipo de solicitud a crear. Los parámetros serán:
    
    -   tipoSolicitud=nueva (por defecto)
        
    -   tipoSolicitud=refrendo
        
    -   tipoSolicitud=cambioDomicilio
        
2.  **Esquema de Validación Diferenciado:**  
    El esquema de validación deberá ajustarse según el tipo de solicitud:
    
    -   Para REFRENDO, se requerirá un esquema de validación diferente, considerando las particularidades de este tipo de solicitud.
        
3.  **Condiciones en el Handler:**  
    Se deben agregar condiciones en el handler create.handlers.solicitud-programa.adapters para manejar la lógica específica de cada tipo de solicitud, incluyendo REFRENDO.
    
4.  **Modificación del Use Case para REFRENDO:**  
    Se debe modificar el use case existente para REFRENDO, el cual ya está implementado, pero requiere ajustes para adecuarse a los cambios propuestos.
    
5.  **Copia de Información de la Solicitud Origen:**  
    Para el tipo de solicitud REFRENDO:
    
    -   Se copiará información de la solicitud origen, replicando de manera casi exacta su contenido.
        
    -   Se utilizará un archivo de configuración para mapear las secciones que se deben copiar de la solicitud origen. Ejemplo: seccionesTipoSolicitud.json.  
          
        ejemplo
        
        ```
        {
           "refrendo":[
              "programa",
              "asignaturas",
              "docentes",
              "trayectoria"
           ],
           "cambioDomicilio":[
              "domicilio"
           ]
        }
        ```
        
6.  **Folio Consecutivo:**  
    El folio de la solicitud REFRENDO deberá ser consecutivo a los anteriores, siguiendo el mismo patrón utilizado para las nuevas solicitudes.
    
7.  **Preparación de la Solicitud de REFRENDO:**
    
    -   La copia de la solicitud origen debe estar lista, basándose en las secciones o tablas especificadas en el archivo de configuración mencionado anteriormente.
        
    -   Esto implicará realizar búsquedas de información anidada en la solicitud origen, peo creando sus nuevos IDs.
        

**Nota:**

-   Para la copia de la solicitud REFRENDO, se deberán incluir datos específicos **del plan de estudio, asignaturas, docentes y plantel**. Para más detalles, consultar con Joel para garantizar la integridad de la información.
