### PR TITLE
Cambio Validacion 

### DIFF
--- a/packages/administracionAcademica/src/use-cases/db/validaciones/create.alumno-validacion.use-cases.js
+++ b/packages/administracionAcademica/src/use-cases/db/validaciones/create.alumno-validacion.use-cases.js
@@ -25,14 +25,14 @@ const createAlumnoValidacion = (
     Usuario: [usuarioId, findOneUsuarioQuery],
     Estado: [estadoId, findOneEstadoQuery],
     Nivel: [nivelId, findOneNivelQuery],
-    SituacionesValidacion: [tipoValidacionId, findOneSituacionesValidacionQuery],
-    TipoValidaciones: [situacionValidacionId, findOneTipoValidacionesQuery],
+    SituacionesValidacion: [situacionValidacionId, findOneSituacionesValidacionQuery],
+    TipoValidaciones: [tipoValidacionId, findOneTipoValidacionesQuery],
   };
   const { Alumno, ...validatorFunctions } = queryFunctions;
   await checkers.findValidator({ Alumno });
   const alumnoDuplicate = await findOneValidacionesQuery({ alumnoId }, { attributes: ['id'] });
   if (alumnoDuplicate) {
-    throw boom.conflict(`Alumno ${alumnoId} already exists`);
+    throw boom.conflict(`Validación with alumnoId: ${alumnoId} already exists`);
   }
   await checkers.findValidator(validatorFunctions);
 

--- a/packages/api-gateway/src/drivers/http/routes/alumnos/schema/create.validacion.schema.js
+++ b/packages/api-gateway/src/drivers/http/routes/alumnos/schema/create.validacion.schema.js
@@ -5,25 +5,23 @@ const { alumnoId, ...data } = validacion;
 
 const createValidacionSchema = {
   tags: ['Alumnos'],
-  description: 'Validate students.',
+  description:
+    'Validate students.',
   params: {
     type: 'object',
-    properties: {
-      alumnoId: { type: 'number' },
-    },
+    properties: { alumnoId },
     required: ['alumnoId'],
   },
   body: {
     type: 'object',
     properties: {
-      ...data, // Asegúrate de que esto expanda las propiedades correctamente
-      folio: { type: 'string' },
+      ...data,
     },
     required: [
-      'usuarioId', // Verifica que estas propiedades realmente existan en `data`
+      'usuarioId',
       'estadoId',
       'nivelId',
-
+      'tipoValidacionId',
       'situacionValidacionId',
       'folio',
     ],
@@ -36,7 +34,8 @@ const createValidacionSchema = {
           type: 'object',
           properties: {
             id: { type: 'integer' },
-            ...responseProperties, // Inclusión de propiedades adicionales
+            ...validacion,
+            ...responseProperties,
           },
         },
       },

--- a/packages/api-gateway/src/drivers/http/routes/alumnos/schema/create.validacion.schema.js
+++ b/packages/api-gateway/src/drivers/http/routes/alumnos/schema/create.validacion.schema.js
@@ -5,24 +5,25 @@ const { alumnoId, ...data } = validacion;
 
 const createValidacionSchema = {
   tags: ['Alumnos'],
-  description:
-    'Validate students.',
+  description: 'Validate students.',
   params: {
     type: 'object',
-    properties: { alumnoId },
+    properties: {
+      alumnoId: { type: 'number' },
+    },
     required: ['alumnoId'],
   },
   body: {
     type: 'object',
     properties: {
-      ...data,
+      ...data, // Asegúrate de que esto expanda las propiedades correctamente
+      folio: { type: 'string' },
     },
     required: [
-      'alumnoId',
-      'usuarioId',
+      'usuarioId', // Verifica que estas propiedades realmente existan en `data`
       'estadoId',
       'nivelId',
-      'tipoValidacionId',
+
       'situacionValidacionId',
       'folio',
     ],
@@ -35,8 +36,7 @@ const createValidacionSchema = {
           type: 'object',
           properties: {
             id: { type: 'integer' },
-            ...validacion,
-            ...responseProperties,
+            ...responseProperties, // Inclusión de propiedades adicionales
           },
         },
       },


### PR DESCRIPTION
Modificación en la definición de alumnoId en params:
- En el código original, la propiedad alumnoId se referenciaba directamente desde el objeto validacion.
- En la corrección, se define explícitamente alumnoId con { type: 'number' }, proporcionando un tipo de dato específico.
Adición explícita de la propiedad folio en body:
- En el código original, folio parece ser incluido en la expansión de ...data sin una definición explícita en el schema.
- En la corrección, se añade explícitamente folio: { type: 'string' }, definiendo su tipo.
Cambio en las propiedades requeridas en body:
- En el original, tipoValidacionId aparece como requerido.
- En la corrección, esta propiedad no está listada entre los requeridos, y se añade un comentario para verificar si las propiedades listadas realmente existen en data.
Modificación en la estructura de response:
- En el original, las propiedades adicionales de validacion se incluyen en la respuesta.
- En la corrección, se omiten las propiedades de validacion (excepto las ya incluidas en data), y se enfatiza la inclusión de responseProperties con un comentario, indicando que se incluyen propiedades adicionales.