### PR TITLE
feat: Update estatusSolicitudId to COMPLETAR SOLICITUD in createRefre…

### DIFF
--- a/packages/solicitudes/src/use-cases/db/solicitudes/create.solicitud-refrendo-programa.use-cases.js
+++ b/packages/solicitudes/src/use-cases/db/solicitudes/create.solicitud-refrendo-programa.use-cases.js
@@ -71,7 +71,7 @@ const createRefrendoSolicitudPrograma = (
     ...solicitudDataWithoutIds,
     folio: folioSolcitud,
     tipoSolicitudId: 2,
-    estatusSolicitudId: 2,
+    estatusSolicitudId: 1,
   };
 
   // Create a new solicitud object with the extracted data


### PR DESCRIPTION
# Modoficar createRefrendo

### Problematica

Al guardar la solicitud el estatus se va a revisión de documentación, no permitiendo editar el refrendo

### Solución

Se identifico que se estaba guardando bajo estatusSolicitudId 2 que significa que esta en proceso revisión de documentos, se cambio al estatus 1 que es *Solicitud en proceso de llenado*