### PR TITLE
Creación de Tablas: SDT-669

### DIFF
--- a/packages/core/src/drivers/db/migrations/20220718180952-create-usuarios-table.js
+++ b/packages/core/src/drivers/db/migrations/20220718180952-create-usuarios-table.js
@@ -113,6 +113,8 @@ const { SOLICITUD_REV_EQUIV_TABLE, SolicitudRevEquivSchema } = require('../model
 const { INTERESADO_TABLE, InteresadoSchema } = require('../models/interesados');
 const { SOLICITUD_REV_EQUIV_INTERESADO_TABLE, SolicitudRevEquivInteresadoSchema } = require('../models/solicitudRevEquivInteresado');
 const { INSTITUCION_PROCEDENCIA_TABLE, InstitucionProcedenciaSchema } = require('../models/institucionesProcedencia');
+const { ASIGNATURA_ANTECEDENTE_TABLE, AsignaturaAntecedenteSchema } = require('../models/asignaturaAntecedentes');
+const { ASIGNATURA_EQUIVALENTE_TABLE, AsignaturaEquivalenteSchema } = require('../models/asignaturaEquivalente');
 
 module.exports = {
   async up(queryInterface) {
@@ -246,6 +248,8 @@ module.exports = {
       SolicitudRevEquivInteresadoSchema,
     );
     await queryInterface.createTable(INSTITUCION_PROCEDENCIA_TABLE, InstitucionProcedenciaSchema);
+    await queryInterface.createTable(ASIGNATURA_ANTECEDENTE_TABLE, AsignaturaAntecedenteSchema);
+    await queryInterface.createTable(ASIGNATURA_EQUIVALENTE_TABLE, AsignaturaEquivalenteSchema);
   },
 
   async down(queryInterface) {
@@ -365,5 +369,7 @@ module.exports = {
     await queryInterface.dropTable(INTERESADO_TABLE);
     await queryInterface.dropTable(SOLICITUD_REV_EQUIV_INTERESADO_TABLE);
     await queryInterface.dropTable(INSTITUCION_PROCEDENCIA_TABLE);
+    await queryInterface.dropTable(ASIGNATURA_ANTECEDENTE_TABLE);
+    await queryInterface.dropTable(ASIGNATURA_EQUIVALENTE_TABLE);
   },
 };

--- a/packages/core/src/drivers/db/models/asignaturaAntecedentes.js
+++ b/packages/core/src/drivers/db/models/asignaturaAntecedentes.js
@@ -1,0 +1,67 @@
+const { Model, DataTypes, Sequelize } = require('sequelize');
+const { SOLICITUD_REV_EQUIV_TABLE } = require('./solicitudesRevEquiv');
+
+const ASIGNATURA_ANTECEDENTE_TABLE = 'asignaturas_antecedentes';
+
+const AsignaturaAntecedenteSchema = {
+  id: {
+    allowNull: false,
+    autoIncrement: true,
+    primaryKey: true,
+    type: DataTypes.INTEGER,
+  },
+  solicitudRevEquivId: {
+    allowNull: false,
+    type: DataTypes.INTEGER,
+    field: 'solicitud_rev_equiv_id',
+    references: {
+      model: SOLICITUD_REV_EQUIV_TABLE,
+      key: 'id',
+    },
+  },
+  nombre: {
+    allowNull: false,
+    type: DataTypes.STRING,
+  },
+  calificacion: {
+    allowNull: false,
+    type: DataTypes.STRING,
+  },
+  createdAt: {
+    allowNull: false,
+    type: DataTypes.DATE,
+    field: 'created_at',
+    defaultValue: Sequelize.NOW,
+  },
+  updatedAt: {
+    type: DataTypes.DATE,
+    field: 'updated_at',
+    defaultValue: null,
+  },
+  deletedAt: {
+    type: DataTypes.DATE,
+    field: 'deleted_at',
+    defaultValue: null,
+  },
+};
+
+class AsignaturaAntecedente extends Model {
+  static associate(models) {
+    this.belongsTo(models.SolicitudRevEquiv, { as: 'solicitudRevEquiv' });
+  }
+
+  static config(sequelize) {
+    return {
+      sequelize,
+      tableName: ASIGNATURA_ANTECEDENTE_TABLE,
+      modelName: 'AsignaturaAntecedente',
+      timestamps: false,
+    };
+  }
+}
+
+module.exports = {
+  ASIGNATURA_ANTECEDENTE_TABLE,
+  AsignaturaAntecedenteSchema,
+  AsignaturaAntecedente,
+};

--- a/packages/core/src/drivers/db/models/asignaturaEquivalente.js
+++ b/packages/core/src/drivers/db/models/asignaturaEquivalente.js
@@ -1,0 +1,78 @@
+const { Model, DataTypes, Sequelize } = require('sequelize');
+const { SOLICITUD_REV_EQUIV_TABLE } = require('./solicitudesRevEquiv');
+const { ASIGNATURA_TABLE } = require('./asignatura');
+
+const ASIGNATURA_EQUIVALENTE_TABLE = 'asignaturas_equivalentes';
+
+const AsignaturaEquivalenteSchema = {
+  id: {
+    allowNull: false,
+    autoIncrement: true,
+    primaryKey: true,
+    type: DataTypes.INTEGER,
+  },
+  solicitudRevEquivId: {
+    allowNull: false,
+    type: DataTypes.INTEGER,
+    field: 'solicitud_rev_equiv_id',
+    references: {
+      model: SOLICITUD_REV_EQUIV_TABLE,
+      key: 'id',
+    },
+  },
+  asignaturaId: {
+    allowNull: false,
+    type: DataTypes.INTEGER,
+    field: 'asignatura_id',
+    references: {
+      model: ASIGNATURA_TABLE,
+      key: 'id',
+    },
+  },
+  nombre: {
+    allowNull: false,
+    type: DataTypes.STRING,
+  },
+  calificacion: {
+    allowNull: false,
+    type: DataTypes.STRING,
+  },
+  createdAt: {
+    allowNull: false,
+    type: DataTypes.DATE,
+    field: 'created_at',
+    defaultValue: Sequelize.NOW,
+  },
+  updatedAt: {
+    type: DataTypes.DATE,
+    field: 'updated_at',
+    defaultValue: null,
+  },
+  deletedAt: {
+    type: DataTypes.DATE,
+    field: 'deleted_at',
+    defaultValue: null,
+  },
+};
+
+class AsignaturaEquivalente extends Model {
+  static associate(models) {
+    this.belongsTo(models.SolicitudRevEquiv, { as: 'solicitudRevEquiv' });
+    this.belongsTo(models.Asignatura, { as: 'asignatura' });
+  }
+
+  static config(sequelize) {
+    return {
+      sequelize,
+      tableName: ASIGNATURA_EQUIVALENTE_TABLE,
+      modelName: 'AsignaturaEquivalente',
+      timestamps: false,
+    };
+  }
+}
+
+module.exports = {
+  ASIGNATURA_EQUIVALENTE_TABLE,
+  AsignaturaEquivalenteSchema,
+  AsignaturaEquivalente,
+};

--- a/packages/core/src/drivers/db/models/index.js
+++ b/packages/core/src/drivers/db/models/index.js
@@ -113,6 +113,8 @@ const { SolicitudRevEquiv, SolicitudRevEquivSchema } = require('./solicitudesRev
 const { Interesado, InteresadoSchema } = require('./interesados');
 const { SolicitudRevEquivInteresado, SolicitudRevEquivInteresadoSchema } = require('./solicitudRevEquivInteresado');
 const { InstitucionProcedencia, InstitucionProcedenciaSchema } = require('./institucionesProcedencia');
+const { AsignaturaAntecedente, AsignaturaAntecedenteSchema } = require('./asignaturaAntecedentes');
+const { AsignaturaEquivalente, AsignaturaEquivalenteSchema } = require('./asignaturaEquivalente');
 
 function setupModels(sequelize) {
   // Initialize models
@@ -260,6 +262,8 @@ function setupModels(sequelize) {
     .config(sequelize));
   InstitucionProcedencia.init(InstitucionProcedenciaSchema, InstitucionProcedencia
     .config(sequelize));
+  AsignaturaAntecedente.init(AsignaturaAntecedenteSchema, AsignaturaAntecedente.config(sequelize));
+  AsignaturaEquivalente.init(AsignaturaEquivalenteSchema, AsignaturaEquivalente.config(sequelize));
 
   // Associations
   Ciclo.associate(sequelize.models);
@@ -375,6 +379,8 @@ function setupModels(sequelize) {
   Interesado.associate(sequelize.models);
   SolicitudRevEquivInteresado.associate(sequelize.models);
   InstitucionProcedencia.associate(sequelize.models);
+  AsignaturaAntecedente.associate(sequelize.models);
+  AsignaturaEquivalente.associate(sequelize.models);
 }
 
 module.exports = setupModels;


### PR DESCRIPTION
### Descripción del PR

Este PR agrega dos nuevas tablas a la base de datos para almacenar información sobre las asignaturas antecedentes y las asignaturas equivalentes.

### Cambios realizados

-   Se agregó la tabla  `asignaturas_antecedentes`  con los siguientes campos:
    
    -   `id`: INTEGER, auto-increment, primary key
    -   `solicitudRevEquivId`: INTEGER, references  `solicitudesRevEquiv`
    -   `nombre`: STRING
    -   `calificacion`: STRING
    -   `createdAt`: DATE, default value  `Sequelize.NOW`
    -   `updatedAt`: DATE, default value  `null`
    -   `deletedAt`: DATE, default value  `null`
-   Se agregó la tabla  `asignaturas_equivalentes`  con los siguientes campos:
    
    -   `id`: INTEGER, auto-increment, primary key
    -   `solicitudRevEquivId`: INTEGER, references  `solicitudesRevEquiv`
    -   `asignaturaId`: INTEGER, references  `asignatura`
    -   `nombre`: STRING
    -   `calificacion`: STRING
    -   `createdAt`: DATE, default value  `Sequelize.NOW`
    -   `updatedAt`: DATE, default value  `null`
    -   `deletedAt`: DATE, default value  `null`

### Cómo probar

1.  Ejecutar las migraciones para crear las nuevas tablas.
2.  Verificar que las tablas  `asignaturas_antecedentes`  y  `asignaturas_equivalentes`  se hayan creado correctamente en la base de datos.
3.  Revertir las migraciones y verificar que las tablas se eliminen correctamente.

### Referencias

-   Ejemplo de código para la tabla  `asignaturas_antecedentes`
-   Ejemplo de código para la tabla  `asignaturas_equivalentes`

### Actualización del archivo de migración

Se actualizó el archivo de migración  `20220718180952-create-usuarios-table.js`  para incluir las nuevas tablas en el método  `down`  para eliminar las tablas en caso de revertir la migración: