### PR TITLE
 SDT-883(feat): Endpoint para buscar lista de niveles

### DIFF
--- a/packages/api-gateway/src/drivers/http/adapters/index.js
+++ b/packages/api-gateway/src/drivers/http/adapters/index.js
@@ -31,6 +31,7 @@ const solicitudesBecasAdapter = require('./solicitudesBecas/handlers');
 const solicitudesServSocAdapter = require('./solicitudesServSoc/handlers');
 const estadosAdapter = require('./estados/handlers');
 const paisesAdapter = require('./paises/handlers');
+const nivelesAdapter = require('./niveles/handlers');
 
 module.exports = {
   diligenciasAdapter,
@@ -65,4 +66,5 @@ module.exports = {
   solicitudesServSocAdapter,
   estadosAdapter,
   paisesAdapter,
+  nivelesAdapter,
 };

--- a/packages/api-gateway/src/drivers/http/adapters/niveles/handlers/find-all.handlers.niveles.adapters.js
+++ b/packages/api-gateway/src/drivers/http/adapters/niveles/handlers/find-all.handlers.niveles.adapters.js
@@ -1,0 +1,18 @@
+const { Logger } = require('@siiges-services/shared');
+const errorHandler = require('../../../utils/errorHandler');
+
+async function findAllNiveles(req, reply) {
+  try {
+    Logger.info('[Niveles]: Getting niveles list');
+
+    const niveles = await this.institucionServices.findAllNiveles();
+    return reply
+      .code(200)
+      .header('Content-Type', 'application/json; charset=utf-8')
+      .send({ data: niveles });
+  } catch (error) {
+    return errorHandler(error, reply);
+  }
+}
+
+module.exports = findAllNiveles;

--- a/packages/api-gateway/src/drivers/http/adapters/niveles/handlers/index.js
+++ b/packages/api-gateway/src/drivers/http/adapters/niveles/handlers/index.js
@@ -1,0 +1,3 @@
+const findAllNiveles = require('./find-all.handlers.niveles.adapters');
+
+module.exports = { findAllNiveles };

--- a/packages/api-gateway/src/drivers/http/routes/publics/niveles/index.js
+++ b/packages/api-gateway/src/drivers/http/routes/publics/niveles/index.js
@@ -1,0 +1,15 @@
+const { nivelesAdapter } = require('../../../adapters');
+
+// const { findAllNivelesSchema } = require('./schema');
+
+async function nivelesRouter(fastify, opts, next) {
+  await fastify.get(
+    '/',
+    //    { schema: findAllNivelesSchema },
+    nivelesAdapter.findAllNiveles,
+  );
+
+  next();
+}
+
+module.exports = nivelesRouter;

--- a/packages/api-gateway/src/drivers/http/routes/publics/niveles/index.js
+++ b/packages/api-gateway/src/drivers/http/routes/publics/niveles/index.js
@@ -1,11 +1,10 @@
 const { nivelesAdapter } = require('../../../adapters');
-
-// const { findAllNivelesSchema } = require('./schema');
+const { findAllNivelesSchema } = require('./schema');
 
 async function nivelesRouter(fastify, opts, next) {
   await fastify.get(
     '/',
-    //    { schema: findAllNivelesSchema },
+    { schema: findAllNivelesSchema },
     nivelesAdapter.findAllNiveles,
   );
 

--- a/packages/api-gateway/src/drivers/http/routes/publics/niveles/schema/find-all.niveles.schema.js
+++ b/packages/api-gateway/src/drivers/http/routes/publics/niveles/schema/find-all.niveles.schema.js
@@ -1,7 +1,7 @@
-const { niveles } = require('../../../privates/grupos/schema/properties/nivel');
+const { nivel } = require('../../../privates/grupos/schema/properties/nivel');
 const { responseProperties } = require('./properties/responseProperties');
 
-const findAllPaisesSchema = {
+const findAllNivelesSchema = {
   tags: ['Nivel'],
   description: 'Return a list of niveles.',
   querystring: {
@@ -20,7 +20,7 @@ const findAllPaisesSchema = {
             type: 'object',
             properties: {
               id: { type: 'integer' },
-              ...niveles,
+              ...nivel,
               ...responseProperties,
             },
           },
@@ -30,4 +30,4 @@ const findAllPaisesSchema = {
   },
 };
 
-module.exports = findAllPaisesSchema;
+module.exports = findAllNivelesSchema;

--- a/packages/api-gateway/src/drivers/http/routes/publics/niveles/schema/find-all.niveles.schema.js
+++ b/packages/api-gateway/src/drivers/http/routes/publics/niveles/schema/find-all.niveles.schema.js
@@ -1,0 +1,33 @@
+const { niveles } = require('../../../privates/grupos/schema/properties/nivel');
+const { responseProperties } = require('./properties/responseProperties');
+
+const findAllPaisesSchema = {
+  tags: ['Nivel'],
+  description: 'Return a list of niveles.',
+  querystring: {
+    type: 'object',
+    properties: {
+      estadoId: { type: 'integer' },
+    },
+  },
+  response: {
+    200: {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' },
+              ...niveles,
+              ...responseProperties,
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+module.exports = findAllPaisesSchema;

--- a/packages/api-gateway/src/drivers/http/routes/publics/niveles/schema/find-all.niveles.schema.js
+++ b/packages/api-gateway/src/drivers/http/routes/publics/niveles/schema/find-all.niveles.schema.js
@@ -2,13 +2,10 @@ const { nivel } = require('../../../privates/grupos/schema/properties/nivel');
 const { responseProperties } = require('./properties/responseProperties');
 
 const findAllNivelesSchema = {
-  tags: ['Nivel'],
-  description: 'Return a list of niveles.',
+  tags: ['Niveles académicos'],
+  description: 'Devuelve una lista de objetos de niveles educativos registrados en el sistema',
   querystring: {
     type: 'object',
-    properties: {
-      estadoId: { type: 'integer' },
-    },
   },
   response: {
     200: {

--- a/packages/api-gateway/src/drivers/http/routes/publics/niveles/schema/index.js
+++ b/packages/api-gateway/src/drivers/http/routes/publics/niveles/schema/index.js
@@ -1,0 +1,3 @@
+const findAllNivelesSchema = require('./find-all.niveles.schema');
+
+module.exports = { findAllNivelesSchema };

--- a/packages/api-gateway/src/drivers/http/routes/publics/niveles/schema/properties/responseProperties.js
+++ b/packages/api-gateway/src/drivers/http/routes/publics/niveles/schema/properties/responseProperties.js
@@ -1,0 +1,8 @@
+// General
+const responseProperties = {
+  createdAt: { type: 'string', format: 'date-time' },
+  updatedAt: { type: 'string', format: 'date-time' },
+  deletedAt: { type: 'string', format: 'date-time' },
+};
+
+module.exports = { responseProperties };

--- a/packages/instituciones/src/adapters/db/index.js
+++ b/packages/instituciones/src/adapters/db/index.js
@@ -102,4 +102,5 @@ module.exports = {
   findOneUsuarioUsuarioQuery: findOneQuery(UsuarioUsuario),
   findOneUsuarioQuery: findOneQuery(Usuario),
   findAllPaisesQuery: findAllQuery(Pais),
+  findAllNivelQuery: findAllQuery(Nivel),
 };

--- a/packages/instituciones/src/useCases/db/niveles/find-all.niveles.use-case.js
+++ b/packages/instituciones/src/useCases/db/niveles/find-all.niveles.use-case.js
@@ -1,0 +1,7 @@
+const findAllNiveles = (findAllNivelesQuery) => async () => {
+  const niveles = await findAllNivelesQuery();
+
+  return niveles;
+};
+
+module.exports = findAllNiveles;

--- a/packages/instituciones/src/useCases/db/niveles/index.js
+++ b/packages/instituciones/src/useCases/db/niveles/index.js
@@ -1,0 +1,9 @@
+const {
+  findAllNivelQuery,
+} = require('../../../adapters/db');
+
+const findAllNiveles = require('./find-all.niveles.use-case');
+
+module.exports = {
+  findAllNiveles: findAllNiveles(findAllNivelQuery),
+};

--- a/packages/instituciones/src/useCases/index.js
+++ b/packages/instituciones/src/useCases/index.js
@@ -11,6 +11,10 @@ const {
 } = require('./db/paises');
 
 const {
+  findAllNiveles,
+} = require('./db/niveles');
+
+const {
   createPlantel,
   findOnePlantel,
   findOnePlantelDetalles,
@@ -110,4 +114,5 @@ module.exports = {
   findAllFormacionDirector,
   findOneFormacionDirector,
   updateFormacionDirector,
+  findAllNiveles,
 };


### PR DESCRIPTION
Este PR implementa un nuevo endpoint en la API para obtener una lista de niveles. El endpoint sigue las mejores prácticas de diseño de APIs RESTful y utiliza esquemas de validación para garantizar la integridad de los datos.
Cambios realizados:
Creación del endpoint /niveles:
http://localhost:3000/api/v1/public/niveles
        Se ha añadido un nuevo endpoint GET /niveles que devuelve una lista de niveles.
Esquema de validación:
 El esquema findAllNivelesSchema define la estructura de la respuesta y los parámetros de consulta permitidos.
 La respuesta incluye un array de objetos con propiedades como id, nivel, y otras propiedades adicionales definidas en responseProperties.