### PR TITLE
SDT-1554: se replico el cambio en mm y se hizo agrego el csv

### DIFF
--- a/packages/api-gateway/src/drivers/http/routes/publics/solicitudesRevEquiv/schema/create.solicitud-rev-equiv.schema.js
+++ b/packages/api-gateway/src/drivers/http/routes/publics/solicitudesRevEquiv/schema/create.solicitud-rev-equiv.schema.js
@@ -58,6 +58,7 @@ const createEquivalenciaSchema = {
             },
             required: [
               'tipoInstitucionId',
+              'paisId',
               'estadoId',
               'nombre',
               'nombreCarrera',
@@ -78,7 +79,7 @@ const createEquivalenciaSchema = {
               required: ['tipoInstitucionId', 'nombre'],
             },
             else: {
-              required: ['tipoInstitucionId', 'nombreCarrera', 'acuerdoRvoe', 'nombre', 'nivel'],
+              required: ['tipoInstitucionId', 'nombreCarrera', 'nivel'],
             },
           },
           asignaturasAntecedentesEquivalentes: {
@@ -115,6 +116,7 @@ const createEquivalenciaSchema = {
       'tipoTramiteId',
       'estatusSolicitudRevEquivId',
       'interesado',
+      'fecha',
     ],
   },
   response: {

--- a/packages/core/src/drivers/db/CSVFiles/tipo_instituciones.csv
+++ b/packages/core/src/drivers/db/CSVFiles/tipo_instituciones.csv
@@ -2,3 +2,4 @@ id,nombre,descripcion,created_at
 1,incorporada,Institución Incorporada,2018-08-08 0:00:00
 2,opd,Órgano Público Descentralizado,2018-08-08 0:00:00
 3,incorporacion federal,Institución con Incorporación Federal,2018-08-08 0:00:00
+4,otro,Otro,2018-08-08 0:00:00


### PR DESCRIPTION
[SDT-1554](https://sicyt-projects.atlassian.net/browse/SDT-1554)

Se actualiza la lógica del backend para validar y procesar los campos según el tipo de solicitud.

Para revalidación parcial, se permiten los campos: nombre_institucion, nivel y programa.
Para revalidación total y duplicado, solo se consideran nivel y programa, ignorando nombre_institucion y rvoe.

Adicionalmente, se agrega soporte para tipo_institucion = "Otro", el cual será enviado por defecto desde el frontend.