### PR TITLE
SDT-1596: se agrego la validacion de aviso de privacidad

### DIFF
--- a/packages/authentication/src/use-cases/strategies/local.strategy.js
+++ b/packages/authentication/src/use-cases/strategies/local.strategy.js
@@ -15,6 +15,10 @@ const localStrategy = (adapter, findOneUserQuery) => async (identifierObj) => {
     throw boom.unauthorized();
   }
 
+  if (!usuarioFound.dataValues.avisoPrivacidad) {
+    throw boom.forbidden('El usuario no ha aceptado el aviso de privacidad y los términos y condiciones de uso.');
+  }
+
   if (usuarioFound.dataValues.actualizado
     ? !adapter.matchHmacPassword(contrasena, usuarioFound.dataValues.contrasena)
     : !adapter.matchHashPassword(contrasena, usuarioFound.dataValues.contrasena)

--- a/packages/core/src/drivers/db/models/usuario.js
+++ b/packages/core/src/drivers/db/models/usuario.js
@@ -53,6 +53,12 @@ const UsuarioSchema = {
     type: Sequelize.BOOLEAN,
     defaultValue: true,
   },
+  avisoPrivacidad: {
+    field: 'aviso_privacidad',
+    allowNull: false,
+    type: DataTypes.BOOLEAN,
+    defaultValue: false,
+  },
   tokenNotificaciones: {
     type: DataTypes.STRING,
     field: 'token_notificaciones',


### PR DESCRIPTION
Se solicitó que el aviso de privacidad fuera un parámetro obligatorio para el login de los usuarios

Así que cree una validación que verifique si ese dato en la base de datos fuera true o false (1,0)
 