### PR TITLE
SDT-1664(feat) : PDF reporte de alumnos inactivos

### DIFF
--- a/packages/api-gateway/src/drivers/http/adapters/alumnos/handlers/find.handlers.alumnos-inactivos-pdf.adapters.js
+++ b/packages/api-gateway/src/drivers/http/adapters/alumnos/handlers/find.handlers.alumnos-inactivos-pdf.adapters.js
@@ -1,0 +1,25 @@
+const { Logger } = require('@siiges-services/shared');
+const errorHandler = require('../../../utils/errorHandler');
+
+async function findAlumnosInactivosPdf(req, reply) {
+  try {
+    const { institucionId, plantelId, programaId } = req.query;
+    Logger.info('[Alumno]: Generando reporte PDF de alumnos inactivos');
+    const alumnos = await this.administracionAcademicaServices.findAllAlumnosInactivos({
+      institucionId: Number(institucionId),
+      plantelId: plantelId ? Number(plantelId) : undefined,
+      programaId: programaId ? Number(programaId) : undefined,
+    });
+    const pdf = await this.filesServices.generarReporteAlumnosInactivos(alumnos);
+
+    return reply
+      .code(200)
+      .header('Content-Type', 'application/pdf')
+      .header('Content-Disposition', 'attachment; filename="reporte-alumnos-inactivos.pdf"')
+      .send(pdf);
+  } catch (error) {
+    return errorHandler(error, reply);
+  }
+}
+
+module.exports = findAlumnosInactivosPdf;

--- a/packages/api-gateway/src/drivers/http/adapters/alumnos/handlers/index.js
+++ b/packages/api-gateway/src/drivers/http/adapters/alumnos/handlers/index.js
@@ -14,6 +14,7 @@ const findAlumnosExtra = require('./find-group.handlers.alumnos-extra.adapters')
 const findOneAlumnoPersona = require('./find-one-alumno-persona.handler');
 const findMatriculaActiva = require('./find-all.handlers.matricula-activa.adapters');
 const findAlumnosInactivos = require('./find.handlers.alumnos-inactivos.adapters');
+const findAlumnosInactivosPdf = require('./find.handlers.alumnos-inactivos-pdf.adapters');
 
 module.exports = {
   createAlumno,
@@ -32,4 +33,5 @@ module.exports = {
   findOneAlumnoPersona,
   findMatriculaActiva,
   findAlumnosInactivos,
+  findAlumnosInactivosPdf,
 };

--- a/packages/api-gateway/src/drivers/http/routes/privates/alumnos/index.js
+++ b/packages/api-gateway/src/drivers/http/routes/privates/alumnos/index.js
@@ -152,6 +152,15 @@ async function asignaturaRouter(fastify, opts, next) {
     alumnosAdapter.findAlumnosInactivos,
   );
 
+  await fastify.get(
+    '/matricula-inactiva/pdf',
+    {
+      schema: alumnosSchema.findAlumnosInactivosPdfSchema,
+      onRequest: [fastify.authenticate],
+    },
+    alumnosAdapter.findAlumnosInactivosPdf,
+  );
+
   next();
 }
 

--- a/packages/api-gateway/src/drivers/http/routes/privates/alumnos/schema/find.alumnos-inactivos-pdf.schema.js
+++ b/packages/api-gateway/src/drivers/http/routes/privates/alumnos/schema/find.alumnos-inactivos-pdf.schema.js
@@ -1,0 +1,15 @@
+const findAlumnosInactivosPdfSchema = {
+  tags: ['Alumnos'],
+  description: 'Obtiene el reporte en PDF de alumnos inactivos por institución.',
+  querystring: {
+    type: 'object',
+    properties: {
+      institucionId: { type: 'integer' },
+      plantelId: { type: 'integer' },
+      programaId: { type: 'integer' },
+    },
+    required: ['institucionId'],
+  },
+};
+
+module.exports = { findAlumnosInactivosPdfSchema };

--- a/packages/api-gateway/src/drivers/http/routes/privates/alumnos/schema/index.js
+++ b/packages/api-gateway/src/drivers/http/routes/privates/alumnos/schema/index.js
@@ -15,6 +15,7 @@ const findAlumnosExtraSchema = require('./find-group.alumnos-extra.schema');
 const findGroupAlumnosPersonaSchema = require('./find-group-alumnos-persona.schema');
 const findMatriculaActivaSchema = require('./find-all.matricula-activa.schema');
 const { findAlumnosInactivosSchema } = require('./find.alumnos-inactivos.schema');
+const { findAlumnosInactivosPdfSchema } = require('./find.alumnos-inactivos-pdf.schema');
 
 module.exports = {
   createAlumnoSchema,
@@ -34,4 +35,5 @@ module.exports = {
   findGroupAlumnosPersonaSchema,
   findMatriculaActivaSchema,
   findAlumnosInactivosSchema,
+  findAlumnosInactivosPdfSchema,
 };

--- a/packages/files/src/index.js
+++ b/packages/files/src/index.js
@@ -6,6 +6,7 @@ const {
   findOneFile,
   getFileIdentifierObj,
   uploadFile,
+  generarReporteAlumnosInactivos,
 } = require('./useCases');
 
 module.exports = {
@@ -13,4 +14,5 @@ module.exports = {
   findOneFile,
   getFileIdentifierObj,
   uploadFile,
+  generarReporteAlumnosInactivos,
 };

--- a/packages/files/src/useCases/generar-reporte-alumnos-inactivos.use-cases.js
+++ b/packages/files/src/useCases/generar-reporte-alumnos-inactivos.use-cases.js
@@ -1,0 +1,9 @@
+const { Logger } = require('@siiges-services/shared');
+
+const generarReporteAlumnosInactivos = (GenerarReporteAlumnosInactivos) => async (alumnos) => {
+  Logger.info('[files.generarReporteAlumnosInactivos.use-case]: Generando reporte de alumnos inactivos');
+  const file = await GenerarReporteAlumnosInactivos(alumnos);
+  return Buffer.from(file);
+};
+
+module.exports = generarReporteAlumnosInactivos;

--- a/packages/files/src/useCases/index.js
+++ b/packages/files/src/useCases/index.js
@@ -1,8 +1,10 @@
 const { buildIdentifierObj, buildFile } = require('./features');
+const { GenerarReporteAlumnosInactivos } = require('../utils/pdfs');
 
 const deleteFile = require('./delete.files.use-cases');
 const uploadFile = require('./upload.files.use-cases');
 const findOneFile = require('./find-one.files.use-cases');
+const generarReporteAlumnosInactivos = require('./generar-reporte-alumnos-inactivos.use-cases');
 
 module.exports = {
   findOneFile: findOneFile(
@@ -14,4 +16,5 @@ module.exports = {
     buildFile,
   ),
   deleteFile,
+  generarReporteAlumnosInactivos: generarReporteAlumnosInactivos(GenerarReporteAlumnosInactivos),
 };

--- a/packages/files/src/utils/pdfs/REPORTE_ALUMNOS_INACTIVOS.js
+++ b/packages/files/src/utils/pdfs/REPORTE_ALUMNOS_INACTIVOS.js
@@ -45,7 +45,7 @@ function GenerarReporteAlumnosInactivos(alumnos) {
     alumno?.persona?.curp || 'No disponible',
     formatearFecha(alumno?.validacion?.fechaInicioAntecedente),
     formatearFecha(alumno?.validacion?.fechaFinAntecedente),
-    formatearFecha(alumno?.validacion?.createdAt),
+    formatearFecha(alumno?.createdAt),
     formatearFecha(alumno?.validacion?.fechaExpedicion),
     alumno?.validacion?.tipo?.descripcion || 'No disponible',
   ]) || [['No hay alumnos inactivos disponibles']];

--- a/packages/files/src/utils/pdfs/REPORTE_ALUMNOS_INACTIVOS.js
+++ b/packages/files/src/utils/pdfs/REPORTE_ALUMNOS_INACTIVOS.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+const path = require('path');
+const { jsPDF } = require('jspdf');
+require('jspdf-autotable');
+
+const imgHeader = fs.readFileSync(path.join(__dirname, '/images/img4.png'), { encoding: 'base64' });
+
+function formatearFecha(fecha) {
+  if (!fecha) return 'No disponible';
+  return new Date(fecha).toLocaleDateString('es-MX');
+}
+
+function GenerarReporteAlumnosInactivos(alumnos) {
+  const JsPDF = jsPDF;
+  const doc = new JsPDF({ orientation: 'landscape' });
+  let currentPositionY = 20;
+
+  doc.addImage(imgHeader, 'JPEG', 60, 9, 100, 23);
+  currentPositionY += 30;
+
+  doc.setFont('Helvetica', 'bold');
+  doc.setFontSize(11);
+  doc.text('SECRETARÍA DE INNOVACIÓN, CIENCIA Y TECNOLOGÍA', 148, currentPositionY, { align: 'center' });
+  doc.setFont('Helvetica', 'normal');
+  doc.setFontSize(10);
+  doc.text('SUBSECRETARÍA DE EDUCACIÓN SUPERIOR', 148, currentPositionY + 5, { align: 'center' });
+  doc.text('REPORTE DE ALUMNOS INACTIVOS', 148, currentPositionY + 10, { align: 'center' });
+  currentPositionY += 20;
+
+  const institucion = alumnos?.[0]?.programa?.plantel?.institucion?.nombre || 'No disponible';
+  const fechaReporte = new Date().toLocaleDateString('es-MX');
+
+  doc.autoTable({
+    startY: currentPositionY,
+    head: [['Institución', 'Fecha de Reporte', 'Total de Alumnos']],
+    body: [[institucion, fechaReporte, alumnos?.length || 0]],
+    theme: 'grid',
+    styles: { fontSize: 10 },
+    headStyles: { fillColor: [172, 178, 183], textColor: [0, 0, 0] },
+  });
+  currentPositionY = doc.previousAutoTable.finalY + 10;
+
+  const alumnosData = alumnos?.map((alumno) => [
+    `${alumno?.persona?.nombre || ''} ${alumno?.persona?.apellidoPaterno || ''} ${alumno?.persona?.apellidoMaterno || ''}`.trim() || 'No disponible',
+    alumno?.persona?.curp || 'No disponible',
+    formatearFecha(alumno?.validacion?.fechaInicioAntecedente),
+    formatearFecha(alumno?.validacion?.fechaFinAntecedente),
+    formatearFecha(alumno?.validacion?.createdAt),
+    formatearFecha(alumno?.validacion?.fechaExpedicion),
+    alumno?.validacion?.tipo?.descripcion || 'No disponible',
+  ]) || [['No hay alumnos inactivos disponibles']];
+
+  doc.autoTable({
+    startY: currentPositionY,
+    head: [[
+      'Nombre',
+      'CURP',
+      'Fecha de Inicio de Antecedentes',
+      'Fecha de Fin de Antecedentes',
+      'Fecha de Creación',
+      'Fecha de Expedición',
+      'Tipo de Validación',
+    ]],
+    body: alumnosData,
+    theme: 'grid',
+    styles: { fontSize: 9 },
+    headStyles: { fillColor: [172, 178, 183], textColor: [0, 0, 0] },
+  });
+
+  return doc.output('arraybuffer');
+}
+
+module.exports = { GenerarReporteAlumnosInactivos };

--- a/packages/files/src/utils/pdfs/index.js
+++ b/packages/files/src/utils/pdfs/index.js
@@ -14,6 +14,7 @@ const { GenerarBeca } = require('./BECA');
 const { GenerarServicio } = require('./SERVICIO_SOCIAL');
 const { GenerarTitulo } = require('./TITULO');
 const { GenerarCertificado } = require('./CERTITULO');
+const { GenerarReporteAlumnosInactivos } = require('./REPORTE_ALUMNOS_INACTIVOS');
 
 module.exports = {
   GenerarFDA02,
@@ -32,4 +33,5 @@ module.exports = {
   GenerarServicio,
   GenerarTitulo,
   GenerarCertificado,
+  GenerarReporteAlumnosInactivos,
 };


### PR DESCRIPTION
## ✨ Reporte PDF de Alumnos Inactivos

Se agregó un endpoint que genera el **reporte en PDF** de alumnos inactivos, reutilizando el mismo filtro (*institución / plantel / programa*) y los mismos datos que ya expone el listado JSON existente.

### 🔗 Endpoint nuevo
GET /api/v1/alumnos/matricula-inactiva/pdf?institucionId={id}&plantelId={opcional}&programaId={opcional}


- **Autenticación:** requerida (mismo header que el resto de rutas de `alumnos`)
- **Respuesta:** PDF directo — `Content-Type: application/pdf`, `Content-Disposition: attachment`

### 📋 Columnas del reporte

| Columna | Origen |
|---|---|
| **Nombre** | `persona.nombre` + apellidos |
| **CURP** | `persona.curp` |
| **Fecha de Inicio de Antecedentes** | `validacion.fechaInicioAntecedente` |
| **Fecha de Fin de Antecedentes** | `validacion.fechaFinAntecedente` |
| **Fecha de Creación** | `createdAt` |
| **Fecha de Expedición** | `validacion.fechaExpedicion` |
| **Tipo de Validación** | `validacion.tipo.descripcion` |

<img width="1254" height="874" alt="imagen" src="https://github.com/user-attachments/assets/d907cb95-a017-4393-a2f4-00eec08990b8" />


### 🗂️ Archivos principales

- [`REPORTE_ALUMNOS_INACTIVOS.js`](packages/files/src/utils/pdfs/REPORTE_ALUMNOS_INACTIVOS.js) — *generador del PDF* (jsPDF + autoTable)
- [`find.handlers.alumnos-inactivos-pdf.adapters.js`](packages/api-gateway/src/drivers/http/adapters/alumnos/handlers/find.handlers.alumnos-inactivos-pdf.adapters.js) — *handler* que consulta y arma la respuesta
- Ruta registrada en [`routes/privates/alumnos/index.js`](packages/api-gateway/src/drivers/http/routes/privates/alumnos/index.js)

### 🧪 Cómo probarlo
GET http://localhost:3000/api/v1/alumnos/matricula-inactiva/pdf?institucionId=34&plantelId=65&programaId=882

> Usa el mismo **token/header de autenticación** que ya usas para `/alumnos/matricula-inactiva`.
> La respuesta es el PDF listo para descargar/visualizar — compáralo contra el JSON de `/alumnos/matricula-inactiva` con los mismos *query params* para confirmar que trae los mismos alumnos y datos.
